### PR TITLE
Fix the cooldown message

### DIFF
--- a/src/inhibitors/cooldown.ts
+++ b/src/inhibitors/cooldown.ts
@@ -20,7 +20,7 @@ botCache.inhibitors.set("cooldown", async function (message, command, guild) {
         sendResponse(
           message,
           `You must wait **${
-            humanizeMilliseconds(now - cooldown.timestamp)
+            humanizeMilliseconds(cooldown.timestamp - now)
           }** before using this command again.`,
         );
         return true;


### PR DESCRIPTION
The cooldown timestamp was calculated wrongly and it was showing as "You must wait -1d -1h -1m -57s  before using this command again."