### PR TITLE
Fixing member argument

### DIFF
--- a/src/arguments/member.ts
+++ b/src/arguments/member.ts
@@ -7,7 +7,7 @@ botCache.arguments.set("member", {
     const [id] = parameters;
     if (!id) return;
 
-    const guild = message.guild();
+    const guild = cache.guilds.get(message.guildID);
     if (!guild) return;
 
     const userID = id.startsWith("<@")


### PR DESCRIPTION
Fixes the member argument type, to the new version of discordeno (message.guild removed)