### PR TITLE
Fixes arguments (for boolean)

### DIFF
--- a/src/monitors/commandHandler.ts
+++ b/src/monitors/commandHandler.ts
@@ -84,7 +84,7 @@ async function parseArguments(
     if (!resolver) continue;
 
     const result = await resolver.execute(argument, params, message, command);
-    if (result) {
+    if (result !== undefined) {
       // Assign the valid argument
       args[argument.name] = result;
       // This will use up all args so immediately exist the loop.


### PR DESCRIPTION
In all the arguments, if the argument isn't validated, it returns undefined but here the check only check for if(result) but since the boolean type return false it makes it invalid when it's valid.
That why it should be a !== undefined