### PR TITLE
Fix subcommand defaultValue bug

### DIFF
--- a/src/monitors/commandHandler.ts
+++ b/src/monitors/commandHandler.ts
@@ -99,6 +99,8 @@ async function parseArguments(
     // Invalid arg provided.
     if (Object.prototype.hasOwnProperty.call(argument, "defaultValue")) {
       args[argument.name] = argument.defaultValue;
+    } else if (command.subcommands?.has(parameters[0])) {
+      continue;
     } else if (argument.required !== false) {
       missingRequiredArg = true;
       argument.missing?.(message);

--- a/src/monitors/commandHandler.ts
+++ b/src/monitors/commandHandler.ts
@@ -148,7 +148,7 @@ async function executeCommand(
 
     // If no subcommand execute the command
     const [argument] = command.arguments || [];
-    const subcommand = argument ? args[argument.name] as Command : undefined;
+    let subcommand = argument ? args[argument.name] as Command : undefined;
 
     if (!argument || argument.type !== "subcommand" || !subcommand) {
       // Check subcommand permissions and options
@@ -163,6 +163,9 @@ async function executeCommand(
       );
     }
 
+    if (!subcommand?.name) {
+      subcommand = command?.subcommands?.get(subcommand as unknown as string) as Command;
+    }
     // A subcommand was asked for in this command
     if (
       ![subcommand.name, ...(subcommand.aliases || [])].includes(parameters[0])


### PR DESCRIPTION
When a command that is build on subcommands (eg. !math) and you do not specify a sub command (eg. !math 1 3) the bot would error out.
Is there a better way of fixing that problem?