### PR TITLE
patch: Fix folder bug

### DIFF
--- a/src/utils/i18next.ts
+++ b/src/utils/i18next.ts
@@ -30,7 +30,7 @@ export async function determineNamespaces(
       namespaces = await determineNamespaces(
         `${path}/${file.name}`,
         namespaces,
-        isLanguage ? "" : `${file.name}/`,
+        isLanguage ? "" : `${folderName + file.name}/`,
       );
     } else {
       namespaces.push(


### PR DESCRIPTION
The determineNamespaces function does not load in the translation keys properly. Here this bug should be fixed.
Eg:
files: commands/ping.json, commands/fun/meow.json
their namespaces would be cached following: commands/ping, fun/meow
So i18next is not able to get the translations right.